### PR TITLE
[FIX] Build fails due to memory overuse

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+node_modules
+build
+dist
+coverage
+.vscode
+.cursor
+.idea
+.DS_Store
+*.log
+.env.local
+storybook-static

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 COPY package*.json ./
 
-RUN npm install 
+RUN npm install
 
 COPY . .
 
@@ -12,7 +12,7 @@ ARG ci_build
 
 RUN mkdir -p /app/log
 
-RUN npm run build:${ci_build}
+RUN NODE_OPTIONS="--max-old-space-size=4096" npm run build:${ci_build}
 
 FROM nginx:stable-alpine
 


### PR DESCRIPTION
- add `.dockerignore`
- add `NODE_OPTIONS="--max-old-space-size=4096"` to limit V8 heap memory. 