### PR TITLE
fix(iam): handle single-day joined and last-login date filtering

### DIFF
--- a/src/components/core/data-table/data-table-date-filter.tsx
+++ b/src/components/core/data-table/data-table-date-filter.tsx
@@ -65,9 +65,9 @@ export const DateRangeFilter = <TData, TValue>({
     setLocalDateRange(selectedDateRange);
     onDateChange(selectedDateRange);
 
-    if (selectedDateRange?.from && selectedDateRange?.to) {
+    if (selectedDateRange?.from) {
       column?.setFilterValue(selectedDateRange);
-    } else if (!selectedDateRange?.from) {
+    } else {
       column?.setFilterValue(undefined);
     }
   };

--- a/src/modules/iam/components/iam-table/iam-table-columns.tsx
+++ b/src/modules/iam/components/iam-table/iam-table-columns.tsx
@@ -1,10 +1,12 @@
 import { ColumnDef } from '@tanstack/react-table';
+import { DateRange } from 'react-day-picker';
 import { Badge } from '@/components/ui-kit/badge';
 import { DataTableColumnHeader } from '@/components/core';
 import { compareValues } from '../../services/user-service';
 import { IamData } from '../../types/user.types';
 import { DataTableRowActions } from './iam-table-row-actions';
 import { CustomtDateFormat } from '@/lib/utils/custom-date/custom-date';
+import { isIamDateInFilterRange } from '../../utils/iam-date-range-filter';
 
 /**
  * Creates the columns for the IAM (Identity and Access Management) table.
@@ -57,6 +59,14 @@ interface ColumnFactoryProps {
   onResendActivation?: (user: IamData) => void;
   t: (key: string) => string;
 }
+
+const dateRangeFilterFn =
+  (accessor: 'createdDate' | 'lastLoggedInTime') =>
+  (row: { getValue: (id: string) => unknown }, id: string, filterValue: DateRange | undefined) => {
+    const raw = row.getValue(id);
+    const rowDate = new Date(raw as string);
+    return isIamDateInFilterRange(rowDate, filterValue, accessor);
+  };
 
 export const createIamTableColumns = ({
   onViewDetails,
@@ -121,11 +131,7 @@ export const createIamTableColumns = ({
       const b = new Date(rowB.original.createdDate).getTime();
       return compareValues(a, b);
     },
-    filterFn: (row, id, value) => {
-      if (!value?.from || !value?.to) return true;
-      const rowDate = new Date(row.getValue(id));
-      return rowDate >= value.from && rowDate <= value.to;
-    },
+    filterFn: dateRangeFilterFn('createdDate'),
   },
   {
     id: 'lastLoggedInTime',
@@ -147,11 +153,7 @@ export const createIamTableColumns = ({
       const b = new Date(rowB.original.lastLoggedInTime).getTime();
       return compareValues(a, b);
     },
-    filterFn: (row, id, value) => {
-      if (!value?.from || !value?.to) return true;
-      const rowDate = new Date(row.getValue(id));
-      return rowDate >= value.from && rowDate <= value.to;
-    },
+    filterFn: dateRangeFilterFn('lastLoggedInTime'),
   },
   {
     id: 'active',

--- a/src/modules/iam/utils/iam-date-range-filter.spec.ts
+++ b/src/modules/iam/utils/iam-date-range-filter.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { isIamDateInFilterRange } from './iam-date-range-filter';
+
+describe('isIamDateInFilterRange', () => {
+  it('includes timestamps later on the same calendar day as a single-day filter', () => {
+    const pickedDay = new Date(2026, 3, 20);
+    const rowDate = new Date(2026, 3, 20, 14, 42, 3);
+    const filter = { from: pickedDay, to: pickedDay };
+
+    expect(isIamDateInFilterRange(rowDate, filter, 'createdDate')).toBe(true);
+    expect(isIamDateInFilterRange(rowDate, filter, 'lastLoggedInTime')).toBe(true);
+  });
+
+  it('treats missing to as a single day using from', () => {
+    const rowDate = new Date(2026, 3, 20, 15, 30, 0);
+    const filter = { from: new Date(2026, 3, 20, 0, 0, 0), to: undefined };
+
+    expect(isIamDateInFilterRange(rowDate, filter, 'createdDate')).toBe(true);
+  });
+
+  it('excludes rows outside the selected local day range', () => {
+    const rowDate = new Date(2026, 3, 19, 12, 0, 0);
+    const filter = { from: new Date(2026, 3, 20), to: new Date(2026, 3, 20) };
+
+    expect(isIamDateInFilterRange(rowDate, filter, 'createdDate')).toBe(false);
+  });
+
+  it('returns true when no filter from date', () => {
+    expect(isIamDateInFilterRange(new Date(), undefined, 'createdDate')).toBe(true);
+  });
+
+  it('excludes last-login sentinel year 1 when filtering', () => {
+    const sentinel = new Date(1, 0, 1);
+    const filter = { from: new Date(2026, 3, 20), to: new Date(2026, 3, 20) };
+
+    expect(isIamDateInFilterRange(sentinel, filter, 'lastLoggedInTime')).toBe(false);
+  });
+});

--- a/src/modules/iam/utils/iam-date-range-filter.ts
+++ b/src/modules/iam/utils/iam-date-range-filter.ts
@@ -1,0 +1,23 @@
+import { endOfDay, isWithinInterval, startOfDay } from 'date-fns';
+import { DateRange } from 'react-day-picker';
+
+/**
+ * Returns whether an instant falls in the selected local calendar range (inclusive).
+ * Single-day selection uses [startOfDay(from), endOfDay(to|from)] so times during that day match.
+ */
+export function isIamDateInFilterRange(
+  rowDate: Date,
+  filterValue: DateRange | undefined,
+  column: 'createdDate' | 'lastLoggedInTime'
+): boolean {
+  if (!filterValue?.from) return true;
+  if (Number.isNaN(rowDate.getTime())) return false;
+  if (column === 'lastLoggedInTime' && rowDate.getFullYear() === 1) return false;
+
+  const rangeStart = startOfDay(new Date(filterValue.from));
+  const rangeEnd = endOfDay(
+    filterValue.to != null ? new Date(filterValue.to) : new Date(filterValue.from)
+  );
+
+  return isWithinInterval(rowDate, { start: rangeStart, end: rangeEnd });
+}


### PR DESCRIPTION
Treat selected day ranges as full local-day intervals. Apply date-column filter values as soon as a start date is selected, so same-day IAM records remain visible.

